### PR TITLE
fix: tf のバックエンドについて明示的に webgl を指定して初期化

### DIFF
--- a/src/features/Cameras/useCamera.ts
+++ b/src/features/Cameras/useCamera.ts
@@ -4,10 +4,13 @@ import { initVideoCamera } from "./initVideoCamera";
 import { initDetector } from "./initDetector";
 import { getVideoElement } from "@/utilities/getHTMLElement";
 import "@tensorflow/tfjs-backend-webgl";
+import * as tf from "@tensorflow/tfjs-core";
 
 export function useCamera() {
   useEffect(() => {
     async function main() {
+      await tf.ready();
+      await tf.setBackend("webgl");
       await initVideoCamera();
       const detector = await initDetector();
       const video = getVideoElement();


### PR DESCRIPTION
以下の公式ドキュメントを参考に、環境によっては webgl が自動利用されないケースがある（ #4 では webgpu が自動選択されている）ため、明示的に使用するバックエンドを指定。
- https://www.tensorflow.org/js/guide/platform_environment?hl=ja#%E3%83%90%E3%83%83%E3%82%AF%E3%82%A8%E3%83%B3%E3%83%89