### PR TITLE
Feature/virtual button judge

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",

--- a/src/features/Cameras/scripts/lib/canvas/virtualButtons.ts
+++ b/src/features/Cameras/scripts/lib/canvas/virtualButtons.ts
@@ -28,83 +28,80 @@ export const virtualButtons = {
   },
   // 0: 通常状態のカラー      1:押されている状態のカラー
   colors: ["rgba(100, 100, 100, 0.8)", "rgba(255, 100, 0, 0.3)"],
-
-  draw_grid: function () {
-    // Canvas要素を取得
-    const canvas = getCanvasElement();
-    const context = getCanvasContext(canvas);
-
-    let width_rate_sum = [0];
-    let height_rate_sum = [0];
-    let cnt = 0;
-    for (let i = 0; i < this.grid_width; i++) {
-      cnt += this.width_rate[i];
-      width_rate_sum.push(cnt);
-    }
-    cnt = 0;
-    for (let i = 0; i < this.grid_height; i++) {
-      cnt += this.height_rate[i];
-      height_rate_sum.push(cnt);
-    }
-
-    for (let i = 0; i < this.grid_width; i++) {
-      let x = canvas.width * width_rate_sum[i];
-
-      context.beginPath();
-      context.moveTo(x, 0); //始点
-      context.lineTo(x, canvas.height); //終点
-      context.closePath();
-      context.stroke();
-    }
-    for (let i = 0; i < this.grid_height; i++) {
-      let y = canvas.height * height_rate_sum[i];
-
-      context.beginPath();
-      context.moveTo(0, y); //始点
-      context.lineTo(canvas.width, y); //終点
-      context.closePath();
-      context.stroke();
-    }
-  },
-  draw: function (poses: Pose[]) {
-    // Canvas要素を取得
-    const canvas = getCanvasElement();
-    const context = getCanvasContext(canvas);
-
-    let keypoints: Keypoint[] =
-      poses.length != 0 ? poses[0].keypoints : Array();
-
-    let height_rate_sum = [0];
-    let width_rate_sum = [0];
-    let cnt = 0;
-    for (let i = 0; i < this.grid_height; i++) {
-      cnt += this.height_rate[i];
-      height_rate_sum.push(cnt);
-    }
-    cnt = 0;
-    for (let i = 0; i < this.grid_width; i++) {
-      cnt += this.width_rate[i];
-      width_rate_sum.push(cnt);
-    }
-
-    // 仮想ボタンの描画
-    for (let i = 0; i < this.grid_height; i++) {
-      for (let j = 0; j < this.grid_width; j++) {
-        if (!this.buttons_visibility[i * this.grid_width + j]) continue;
-
-        let x1, y1, x2, y2: number;
-        y1 = canvas.height * height_rate_sum[i];
-        x1 = canvas.width * width_rate_sum[j];
-        y2 = canvas.height * height_rate_sum[i + 1];
-        x2 = canvas.width * width_rate_sum[j + 1];
-
-        context.fillStyle = this.colors[0];
-        context.fillRect(x1, y1, x2 - x1, y2 - y1);
-      }
-    }
-  },
 };
 
-// function getKeypointByName(keypoints : Keypoint[], targetName: String) {
-//   return keypoints.find( ( point :Keypoint ) => point.name === targetName);
-// }
+export function buttons_draw_grid() {
+  // Canvas要素を取得
+  const canvas = getCanvasElement();
+  const context = getCanvasContext(canvas);
+
+  let width_rate_sum = [0];
+  let height_rate_sum = [0];
+  let cnt = 0;
+  for (let i = 0; i < virtualButtons.grid_width; i++) {
+    cnt += virtualButtons.width_rate[i];
+    width_rate_sum.push(cnt);
+  }
+  cnt = 0;
+  for (let i = 0; i < virtualButtons.grid_height; i++) {
+    cnt += virtualButtons.height_rate[i];
+    height_rate_sum.push(cnt);
+  }
+
+  for (let i = 0; i < virtualButtons.grid_width; i++) {
+    let x = canvas.width * width_rate_sum[i];
+
+    context.beginPath();
+    context.moveTo(x, 0); //始点
+    context.lineTo(x, canvas.height); //終点
+    context.closePath();
+    context.stroke();
+  }
+  for (let i = 0; i < virtualButtons.grid_height; i++) {
+    let y = canvas.height * height_rate_sum[i];
+
+    context.beginPath();
+    context.moveTo(0, y); //始点
+    context.lineTo(canvas.width, y); //終点
+    context.closePath();
+    context.stroke();
+  }
+}
+
+export function buttons_draw(poses: Pose[]) {
+  // Canvas要素を取得
+  const canvas = getCanvasElement();
+  const context = getCanvasContext(canvas);
+
+  let keypoints: Keypoint[] = poses.length != 0 ? poses[0].keypoints : Array();
+
+  let height_rate_sum = [0];
+  let width_rate_sum = [0];
+  let cnt = 0;
+  for (let i = 0; i < virtualButtons.grid_height; i++) {
+    cnt += virtualButtons.height_rate[i];
+    height_rate_sum.push(cnt);
+  }
+  cnt = 0;
+  for (let i = 0; i < virtualButtons.grid_width; i++) {
+    cnt += virtualButtons.width_rate[i];
+    width_rate_sum.push(cnt);
+  }
+
+  // 仮想ボタンの描画
+  for (let i = 0; i < virtualButtons.grid_height; i++) {
+    for (let j = 0; j < virtualButtons.grid_width; j++) {
+      if (!virtualButtons.buttons_visibility[i * virtualButtons.grid_width + j])
+        continue;
+
+      let x1, y1, x2, y2: number;
+      y1 = canvas.height * height_rate_sum[i];
+      x1 = canvas.width * width_rate_sum[j];
+      y2 = canvas.height * height_rate_sum[i + 1];
+      x2 = canvas.width * width_rate_sum[j + 1];
+
+      context.fillStyle = virtualButtons.colors[0];
+      context.fillRect(x1, y1, x2 - x1, y2 - y1);
+    }
+  }
+}

--- a/src/features/Cameras/scripts/lib/canvas/virtualButtons.ts
+++ b/src/features/Cameras/scripts/lib/canvas/virtualButtons.ts
@@ -24,7 +24,10 @@ export const virtualButtons = {
   ],
   valid_keypoints: ["right_wrist", "left_wrist", "right_ankle", "left_ankle"],
   // 0: 通常状態のカラー      1:押されている状態のカラー
-  colors: ["rgba(100, 100, 100, 0.8)", "rgba(255, 100, 0, 0.3)"],
+  colors: {
+    normal: "rgba(100, 100, 100, 0.8)",
+    pressed: "rgba(255, 100, 0, 0.3)",
+  },
 
   height_rate_sum: Array(),
   width_rate_sum: Array(),
@@ -97,11 +100,11 @@ export function buttons_draw(poses: Pose[]) {
       y2 = canvas.height * virtualButtons.height_rate_sum[i + 1];
       x2 = canvas.width * virtualButtons.width_rate_sum[j + 1];
 
-      context.fillStyle = virtualButtons.colors[0];
+      context.fillStyle = virtualButtons.colors.normal;
 
       for (let target of virtualButtons.valid_keypoints) {
         if (contains(i, j, keypoints, target)) {
-          context.fillStyle = virtualButtons.colors[1];
+          context.fillStyle = virtualButtons.colors.pressed;
         }
       }
 
@@ -118,7 +121,7 @@ function findKeypointByName(
 }
 
 function contains(h: number, w: number, keypoints: Keypoint[], target: String) {
-  let pnt: Keypoint = findKeypointByName(keypoints, target) as Keypoint;
+  let pnt = findKeypointByName(keypoints, target);
 
   if (pnt == null) return false;
 

--- a/src/features/Cameras/scripts/lib/canvas/virtualButtons.ts
+++ b/src/features/Cameras/scripts/lib/canvas/virtualButtons.ts
@@ -118,14 +118,16 @@ function findKeypointByName(
 }
 
 function contains(h: number, w: number, keypoints: Keypoint[], target: String) {
+  let pnt: Keypoint = findKeypointByName(keypoints, target) as Keypoint;
+
+  if (pnt == null) return false;
+
   let x1, y1, x2, y2: number;
   let canvas = getCanvasElement();
   y1 = canvas.height * virtualButtons.height_rate_sum[h];
   x1 = canvas.width * virtualButtons.width_rate_sum[w];
   y2 = canvas.height * virtualButtons.height_rate_sum[h + 1];
   x2 = canvas.width * virtualButtons.width_rate_sum[w + 1];
-
-  let pnt: Keypoint = findKeypointByName(keypoints, target) as Keypoint;
 
   return x1 <= pnt.x && pnt.x <= x2 && y1 <= pnt.y && pnt.y <= y2;
 }

--- a/src/features/Cameras/scripts/lib/canvas/virtualButtons.ts
+++ b/src/features/Cameras/scripts/lib/canvas/virtualButtons.ts
@@ -4,48 +4,64 @@ import {
   getCanvasElement,
 } from "@/features/Cameras/scripts/utils/getHTMLElement";
 
+/**
+ * 3x3のグリッドとしてボタンを配置する
+ *
+ * index :
+ *    0 1 2
+ *    3 4 5
+ *    6 7 8
+ */
 export const virtualButtons = {
-  size: 6,
-  points: [
-    [0, 0, 1, 1],
-    [0, 3, 1, 1],
-    [3, 0, 1, 1],
-    [3, 3, 1, 1],
-    [0, 1, 1, 2],
-    [3, 1, 1, 2],
-  ],
+  grid_height: 3,
+  grid_width: 3,
+  height_rate: [0.25, 0.5, 0.25], // 各行の幅の比
+  width_rate: [0.25, 0.5, 0.25], // 各列の幅の比
+  buttons_visibility: [true, false, true, true, false, true, true, false, true],
+  valid_keypoints: ["right_wrist", "left_wrist", "right_ankle", "left_ankle"],
+  buttons_state: {
+    none: 0,
+    left_hand: 1,
+    right_hand: 2,
+    left_ankle: 3,
+    right_ankle: 4,
+  },
   // 0: 通常状態のカラー      1:押されている状態のカラー
-  colors: ["rgba(100, 100, 100, 0.3)", "rgba(255, 100, 0, 0.3)"],
-  width: 4,
-  height: 4,
+  colors: ["rgba(100, 100, 100, 0.8)", "rgba(255, 100, 0, 0.3)"],
+
   draw_grid: function () {
     // Canvas要素を取得
     const canvas = getCanvasElement();
     const context = getCanvasContext(canvas);
 
-    for (let i = 0; i < this.width; i++) {
-      let x = (i * canvas.width) / this.width;
+    let width_rate_sum = [0];
+    let height_rate_sum = [0];
+    let cnt = 0;
+    for (let i = 0; i < this.grid_width; i++) {
+      cnt += this.width_rate[i];
+      width_rate_sum.push(cnt);
+    }
+    cnt = 0;
+    for (let i = 0; i < this.grid_height; i++) {
+      cnt += this.height_rate[i];
+      height_rate_sum.push(cnt);
+    }
 
-      // パスの開始
+    for (let i = 0; i < this.grid_width; i++) {
+      let x = canvas.width * width_rate_sum[i];
+
       context.beginPath();
-      // 線の開始位置
-      context.moveTo(x, 0);
-      // 開始以降の線の位置
-      context.lineTo(x, canvas.height);
-      // パスを閉じる
+      context.moveTo(x, 0); //始点
+      context.lineTo(x, canvas.height); //終点
       context.closePath();
       context.stroke();
     }
-    for (let i = 0; i < this.height; i++) {
-      let y = (i * canvas.height) / this.height;
+    for (let i = 0; i < this.grid_height; i++) {
+      let y = canvas.height * height_rate_sum[i];
 
-      // パスの開始
       context.beginPath();
-      // 線の開始位置
-      context.moveTo(0, y);
-      // 開始以降の線の位置
-      context.lineTo(canvas.width, y);
-      // パスを閉じる
+      context.moveTo(0, y); //始点
+      context.lineTo(canvas.width, y); //終点
       context.closePath();
       context.stroke();
     }
@@ -55,26 +71,40 @@ export const virtualButtons = {
     const canvas = getCanvasElement();
     const context = getCanvasContext(canvas);
 
-    // 点を描画
     let keypoints: Keypoint[] =
       poses.length != 0 ? poses[0].keypoints : Array();
 
-    for (let i = 0; i < this.size; i++) {
-      context.fillStyle = this.colors[0];
-      let x = (this.points[i][0] * canvas.width) / this.width;
-      let y = (this.points[i][1] * canvas.height) / this.height;
-      let l1 = (this.points[i][2] * canvas.width) / this.width;
-      let l2 = (this.points[i][3] * canvas.height) / this.height;
+    let height_rate_sum = [0];
+    let width_rate_sum = [0];
+    let cnt = 0;
+    for (let i = 0; i < this.grid_height; i++) {
+      cnt += this.height_rate[i];
+      height_rate_sum.push(cnt);
+    }
+    cnt = 0;
+    for (let i = 0; i < this.grid_width; i++) {
+      cnt += this.width_rate[i];
+      width_rate_sum.push(cnt);
+    }
 
-      for (let pnt of keypoints) {
-        if (x <= pnt.x && pnt.x <= x + l1 && y <= pnt.y && pnt.y <= y + l2) {
-          context.fillStyle = this.colors[1];
-          console.log(pnt.name);
-          break;
-        }
+    // 仮想ボタンの描画
+    for (let i = 0; i < this.grid_height; i++) {
+      for (let j = 0; j < this.grid_width; j++) {
+        if (!this.buttons_visibility[i * this.grid_width + j]) continue;
+
+        let x1, y1, x2, y2: number;
+        y1 = canvas.height * height_rate_sum[i];
+        x1 = canvas.width * width_rate_sum[j];
+        y2 = canvas.height * height_rate_sum[i + 1];
+        x2 = canvas.width * width_rate_sum[j + 1];
+
+        context.fillStyle = this.colors[0];
+        context.fillRect(x1, y1, x2 - x1, y2 - y1);
       }
-
-      context.fillRect(x, y, l1, l2);
     }
   },
 };
+
+// function getKeypointByName(keypoints : Keypoint[], targetName: String) {
+//   return keypoints.find( ( point :Keypoint ) => point.name === targetName);
+// }

--- a/src/features/Cameras/scripts/lib/canvas/virtualButtons.ts
+++ b/src/features/Cameras/scripts/lib/canvas/virtualButtons.ts
@@ -17,17 +17,17 @@ export const virtualButtons = {
   grid_width: 3,
   height_rate: [0.25, 0.5, 0.25], // 各行の幅の比
   width_rate: [0.25, 0.5, 0.25], // 各列の幅の比
-  buttons_visibility: [true, false, true, true, false, true, true, false, true],
+  buttons_visibility: [
+    [true, false, true],
+    [true, false, true],
+    [true, false, true],
+  ],
   valid_keypoints: ["right_wrist", "left_wrist", "right_ankle", "left_ankle"],
-  buttons_state: {
-    none: 0,
-    left_hand: 1,
-    right_hand: 2,
-    left_ankle: 3,
-    right_ankle: 4,
-  },
   // 0: 通常状態のカラー      1:押されている状態のカラー
   colors: ["rgba(100, 100, 100, 0.8)", "rgba(255, 100, 0, 0.3)"],
+
+  height_rate_sum: Array(),
+  width_rate_sum: Array(),
 };
 
 export function buttons_draw_grid() {
@@ -35,21 +35,21 @@ export function buttons_draw_grid() {
   const canvas = getCanvasElement();
   const context = getCanvasContext(canvas);
 
-  let width_rate_sum = [0];
-  let height_rate_sum = [0];
+  virtualButtons.height_rate_sum = [0];
+  virtualButtons.width_rate_sum = [0];
   let cnt = 0;
   for (let i = 0; i < virtualButtons.grid_width; i++) {
     cnt += virtualButtons.width_rate[i];
-    width_rate_sum.push(cnt);
+    virtualButtons.width_rate_sum.push(cnt);
   }
   cnt = 0;
   for (let i = 0; i < virtualButtons.grid_height; i++) {
     cnt += virtualButtons.height_rate[i];
-    height_rate_sum.push(cnt);
+    virtualButtons.height_rate_sum.push(cnt);
   }
 
   for (let i = 0; i < virtualButtons.grid_width; i++) {
-    let x = canvas.width * width_rate_sum[i];
+    let x = canvas.width * virtualButtons.width_rate_sum[i];
 
     context.beginPath();
     context.moveTo(x, 0); //始点
@@ -58,7 +58,7 @@ export function buttons_draw_grid() {
     context.stroke();
   }
   for (let i = 0; i < virtualButtons.grid_height; i++) {
-    let y = canvas.height * height_rate_sum[i];
+    let y = canvas.height * virtualButtons.height_rate_sum[i];
 
     context.beginPath();
     context.moveTo(0, y); //始点
@@ -75,33 +75,57 @@ export function buttons_draw(poses: Pose[]) {
 
   let keypoints: Keypoint[] = poses.length != 0 ? poses[0].keypoints : Array();
 
-  let height_rate_sum = [0];
-  let width_rate_sum = [0];
   let cnt = 0;
   for (let i = 0; i < virtualButtons.grid_height; i++) {
     cnt += virtualButtons.height_rate[i];
-    height_rate_sum.push(cnt);
+    virtualButtons.height_rate_sum.push(cnt);
   }
   cnt = 0;
   for (let i = 0; i < virtualButtons.grid_width; i++) {
     cnt += virtualButtons.width_rate[i];
-    width_rate_sum.push(cnt);
+    virtualButtons.width_rate_sum.push(cnt);
   }
 
   // 仮想ボタンの描画
   for (let i = 0; i < virtualButtons.grid_height; i++) {
     for (let j = 0; j < virtualButtons.grid_width; j++) {
-      if (!virtualButtons.buttons_visibility[i * virtualButtons.grid_width + j])
-        continue;
+      if (!virtualButtons.buttons_visibility[i][j]) continue;
 
       let x1, y1, x2, y2: number;
-      y1 = canvas.height * height_rate_sum[i];
-      x1 = canvas.width * width_rate_sum[j];
-      y2 = canvas.height * height_rate_sum[i + 1];
-      x2 = canvas.width * width_rate_sum[j + 1];
+      y1 = canvas.height * virtualButtons.height_rate_sum[i];
+      x1 = canvas.width * virtualButtons.width_rate_sum[j];
+      y2 = canvas.height * virtualButtons.height_rate_sum[i + 1];
+      x2 = canvas.width * virtualButtons.width_rate_sum[j + 1];
 
       context.fillStyle = virtualButtons.colors[0];
+
+      for (let target of virtualButtons.valid_keypoints) {
+        if (contains(i, j, keypoints, target)) {
+          context.fillStyle = virtualButtons.colors[1];
+        }
+      }
+
       context.fillRect(x1, y1, x2 - x1, y2 - y1);
     }
   }
+}
+
+function findKeypointByName(
+  keypoints: Keypoint[],
+  targetName: String,
+): Keypoint | undefined {
+  return keypoints.find((keypoint) => keypoint.name === targetName);
+}
+
+function contains(h: number, w: number, keypoints: Keypoint[], target: String) {
+  let x1, y1, x2, y2: number;
+  let canvas = getCanvasElement();
+  y1 = canvas.height * virtualButtons.height_rate_sum[h];
+  x1 = canvas.width * virtualButtons.width_rate_sum[w];
+  y2 = canvas.height * virtualButtons.height_rate_sum[h + 1];
+  x2 = canvas.width * virtualButtons.width_rate_sum[w + 1];
+
+  let pnt: Keypoint = findKeypointByName(keypoints, target) as Keypoint;
+
+  return x1 <= pnt.x && pnt.x <= x2 && y1 <= pnt.y && pnt.y <= y2;
 }

--- a/src/features/Cameras/scripts/mainLoop.ts
+++ b/src/features/Cameras/scripts/mainLoop.ts
@@ -34,7 +34,7 @@ export async function main_loop(
       drawKeypoints(poses[0].keypoints);
     }
     virtualButtons.draw(poses);
-    // virtualButtons.draw_grid();
+    virtualButtons.draw_grid();
 
     requestAnimationFrame(() => loop());
   }

--- a/src/features/Cameras/scripts/mainLoop.ts
+++ b/src/features/Cameras/scripts/mainLoop.ts
@@ -1,7 +1,11 @@
 import { PoseDetector } from "@tensorflow-models/pose-detection/dist/pose_detector";
 import { clearCanvas } from "./lib/canvas/clearCanvas";
 import { drawKeypoints } from "./lib/canvas/drawKeypoints";
-import { virtualButtons } from "./lib/canvas/virtualButtons";
+import {
+  virtualButtons,
+  buttons_draw,
+  buttons_draw_grid,
+} from "./lib/canvas/virtualButtons";
 import { getElementById } from "@/features/Cameras/scripts/utils/getHTMLElement";
 
 export async function main_loop(
@@ -33,8 +37,8 @@ export async function main_loop(
     if (poses.length == 1) {
       drawKeypoints(poses[0].keypoints);
     }
-    virtualButtons.draw(poses);
-    virtualButtons.draw_grid();
+    buttons_draw(poses);
+    buttons_draw_grid();
 
     requestAnimationFrame(() => loop());
   }


### PR DESCRIPTION
# 仮想ボタンの判定機能の実装・修正
## 目的
* 仮想ボタン機能（特にメソッド）をオブジェクトに書いていたが、やりにくくなってきたので解体したい
* 各ボタンエリアにどの部位が含まれているのか判定したい

## 変更点
* virtualButtonsオブジェクト内のメソッドをオブジェクトの外に出した
* 仮想ボタンの位置の指定方法を少し変更
  * 画面を3×3のマス目に区切り、それぞれの位置にボタンを配置
  * マス目の幅を比率で指定
* ボタンを押すのに有効なkeypointを厳選（両手・両足のみ） 
* virtualButtons.tsのcontains関数を使って各ボタンに特定の部位が含まれるかを判定可能に

## 改善すべき点
* virtualButtons.tsの中身が大きくなってしまったため、ファイルを分けるべきか
* その他、オブジェクトを解体したところなど、書き方にアドバイスがあればほしいです