### PR TITLE
chore: eslint の `no-unused-vars` ルールを消去

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,6 @@
           "order": "asc"
         }
       }
-    ],
-    "no-unused-vars": "error"
+    ]
   }
 }


### PR DESCRIPTION
TypeScript の関数型宣言でエラーが起こったため