### PR TITLE
カメラ映像を正方形に変更

### DIFF
--- a/src/features/Cameras/Cameras.tsx
+++ b/src/features/Cameras/Cameras.tsx
@@ -8,10 +8,11 @@ export function Cameras() {
       <h1>tensorflow.js test</h1>
       <h3 id="fps">FPS : 0</h3>
       <div id="container" className="relative">
-        <video
-          id="video"
+        <video id="video" className="invisible"></video>
+        <canvas
+          id="camera-canvas"
           className="absolute top-0 left-0 z-0 scale-x-[-1]"
-        ></video>
+        ></canvas>
         <canvas
           id="canvas"
           className="absolute top-0 left-0 z-10 scale-x-[-1]"

--- a/src/features/Cameras/scripts/lib/canvas/drawKeypoints.ts
+++ b/src/features/Cameras/scripts/lib/canvas/drawKeypoints.ts
@@ -1,8 +1,8 @@
 import { Keypoint } from "@tensorflow-models/pose-detection/dist/types";
 import {
+  getCameraCanvasElement,
   getCanvasContext,
   getCanvasElement,
-  getVideoElement,
 } from "@/features/Cameras/scripts/utils/getHTMLElement";
 
 // canvas上にkeypointsを元に点を描画する
@@ -10,9 +10,9 @@ import {
 export function drawKeypoints(keypoints: Keypoint[]) {
   // Canvas要素を取得
   const canvas = getCanvasElement();
-  const video = getVideoElement();
+  const cameraCanvas = getCameraCanvasElement();
 
-  matchCanvasSizeToVideo(canvas, video);
+  matchCanvasSizeToCameraCanvas(canvas, cameraCanvas);
 
   const context = getCanvasContext(canvas);
 
@@ -26,10 +26,10 @@ export function drawKeypoints(keypoints: Keypoint[]) {
 }
 
 // Canvasのサイズをvideoと合わせる
-function matchCanvasSizeToVideo(
+function matchCanvasSizeToCameraCanvas(
   canvas: HTMLCanvasElement,
-  video: HTMLVideoElement,
+  cameraCanvas: HTMLCanvasElement,
 ) {
-  canvas.width = video.videoWidth;
-  canvas.height = video.videoHeight;
+  canvas.width = cameraCanvas.width;
+  canvas.height = cameraCanvas.height;
 }

--- a/src/features/Cameras/scripts/lib/drawCameraCanvas.ts
+++ b/src/features/Cameras/scripts/lib/drawCameraCanvas.ts
@@ -1,0 +1,33 @@
+import {
+  getCameraCanvasElement,
+  getVideoElement,
+} from "../utils/getHTMLElement";
+
+export function drawCameraCanvas() {
+  const video = getVideoElement();
+  const cameraCanvas = getCameraCanvasElement();
+
+  // キャンバスサイズを正方形にする
+  const length = Math.min(video.clientWidth, video.clientHeight);
+  cameraCanvas.width = length;
+  cameraCanvas.height = length;
+
+  // カメラ映像をキャンバスに転写する
+  let sx, sy;
+
+  // 縦長のカメラ
+  if (video.clientWidth < video.clientHeight) {
+    sx = 0;
+    sy = (video.clientHeight - length) / 2;
+  }
+  // 横長のカメラ
+  else {
+    sx = (video.clientWidth - length) / 2;
+    sy = 0;
+  }
+  cameraCanvas
+    .getContext("2d")
+    ?.drawImage(video, sx, sy, length, length, 0, 0, length, length);
+
+  // TODO: スケールを調整する
+}

--- a/src/features/Cameras/scripts/lib/initVideoCamera.ts
+++ b/src/features/Cameras/scripts/lib/initVideoCamera.ts
@@ -4,8 +4,8 @@ export async function initVideoCamera() {
   const video = getVideoElement();
 
   const stream = await navigator.mediaDevices.getUserMedia({
-    video: true,
     audio: false,
+    video: true,
   });
 
   video.srcObject = stream;

--- a/src/features/Cameras/scripts/mainLoop.ts
+++ b/src/features/Cameras/scripts/mainLoop.ts
@@ -5,11 +5,12 @@ import {
   initVirtualButtons,
   buttons_update,
 } from "./lib/canvas/virtualButtons";
+import { drawCameraCanvas } from "./lib/drawCameraCanvas";
 import { getElementById } from "@/features/Cameras/scripts/utils/getHTMLElement";
 
 export async function main_loop(
   detector: PoseDetector,
-  video: HTMLVideoElement,
+  cameraCanvas: HTMLCanvasElement,
 ) {
   let fps = 0;
   let frameCount = 0;
@@ -26,6 +27,7 @@ export async function main_loop(
 
     clearCanvas();
 
+    // FPSの計算
     if (endTime - startTime >= 1000) {
       startTime = endTime;
       fps = frameCount;
@@ -34,7 +36,10 @@ export async function main_loop(
       fpsElement.innerText = "FPS : " + fps;
     }
 
-    const poses = await detector.estimatePoses(video);
+    // videoからcamera-canvasへの転写
+    drawCameraCanvas();
+
+    const poses = await detector.estimatePoses(cameraCanvas);
     if (poses.length == 1) {
       drawKeypoints(poses[0].keypoints);
     }

--- a/src/features/Cameras/scripts/utils/getHTMLElement.ts
+++ b/src/features/Cameras/scripts/utils/getHTMLElement.ts
@@ -12,6 +12,14 @@ export function getVideoElement() {
   return video;
 }
 
+export function getCameraCanvasElement() {
+  const camera = document.getElementById("camera-canvas");
+  if (!isCanvasElement(camera)) {
+    throw new Error("Canvas element not found or is not a canvas element");
+  }
+  return camera;
+}
+
 export function getCanvasElement() {
   const canvas = document.getElementById("canvas");
 

--- a/src/features/Cameras/useCamera.ts
+++ b/src/features/Cameras/useCamera.ts
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 import { initDetector } from "./scripts/lib/initDetector";
 import { initVideoCamera } from "./scripts/lib/initVideoCamera";
 import { main_loop } from "./scripts/mainLoop";
-import { getVideoElement } from "@/features/Cameras/scripts/utils/getHTMLElement";
+import { getCameraCanvasElement } from "@/features/Cameras/scripts/utils/getHTMLElement";
 import "@tensorflow/tfjs-backend-webgl";
 
 export function useCamera() {
@@ -13,8 +13,8 @@ export function useCamera() {
       await tf.setBackend("webgl");
       await initVideoCamera();
       const detector = await initDetector();
-      const video = getVideoElement();
-      main_loop(detector, video);
+      const cameraCanvas = getCameraCanvasElement();
+      main_loop(detector, cameraCanvas);
     }
 
     main();


### PR DESCRIPTION
# Why
カメラ映像を正方形にしたい
# What
* videoタグはそのまま非表示に変更
* 新たにcamera-canvasを追加し、毎フレームごとにvideoの内容をトリミングして転写している
* camera-canvasは一辺の長さがvideoのmin(width,height)
