### PR TITLE
エリアのキーポイントの判定を修正

### DIFF
--- a/src/features/Cameras/scripts/lib/canvas/virtualButtons.ts
+++ b/src/features/Cameras/scripts/lib/canvas/virtualButtons.ts
@@ -124,7 +124,7 @@ export function contains(
   let pnt = findKeypointByName(keypoints, target);
 
   if (pnt == null) return false;
-  if (pnt.score && pnt.score > 0.3) return false;
+  if (pnt.score && pnt.score < 0.3) return false;
 
   let x1, y1, x2, y2: number;
   let canvas = getCanvasElement();

--- a/src/features/Cameras/scripts/lib/canvas/virtualButtons.ts
+++ b/src/features/Cameras/scripts/lib/canvas/virtualButtons.ts
@@ -124,6 +124,7 @@ export function contains(
   let pnt = findKeypointByName(keypoints, target);
 
   if (pnt == null) return false;
+  if (pnt.score && pnt.score > 0.3) return false;
 
   let x1, y1, x2, y2: number;
   let canvas = getCanvasElement();


### PR DESCRIPTION
# Why
キーポイントの表示は、scoreが0.3以上のもののみだったことにたいし、エリアの判定はすべてのキーポイントに対して行っていた。

# What
エリアにscore0,3未満のキーポイントが入っていても無視するように設定。

### scoreとは
判定された姿勢の信頼度(confidence score)
各キーポイントに対して設定されている