### PR TITLE
iPhone のブラウザで MediaStream を video タグにセットしたときの問題の解消

### DIFF
--- a/src/features/Cameras/Cameras.tsx
+++ b/src/features/Cameras/Cameras.tsx
@@ -8,7 +8,13 @@ export function Cameras() {
       <h1>tensorflow.js test</h1>
       <h3 id="fps">FPS : 0</h3>
       <div id="container" className="relative">
-        <video id="video" className="invisible"></video>
+        <video
+          id="video"
+          className="invisible"
+          autoPlay
+          muted
+          playsInline
+        ></video>
         <canvas
           id="camera-canvas"
           className="absolute top-0 left-0 z-0 scale-x-[-1]"

--- a/src/features/Cameras/useCamera.ts
+++ b/src/features/Cameras/useCamera.ts
@@ -9,8 +9,8 @@ import "@tensorflow/tfjs-backend-webgl";
 export function useCamera() {
   useEffect(() => {
     async function main() {
-      // await tf.ready();
-      // await tf.setBackend("webgl");
+      await tf.ready();
+      await tf.setBackend("webgl");
       await initVideoCamera();
       const detector = await initDetector();
       const cameraCanvas = getCameraCanvasElement();

--- a/src/features/Cameras/useCamera.ts
+++ b/src/features/Cameras/useCamera.ts
@@ -9,8 +9,8 @@ import "@tensorflow/tfjs-backend-webgl";
 export function useCamera() {
   useEffect(() => {
     async function main() {
-      await tf.ready();
-      await tf.setBackend("webgl");
+      // await tf.ready();
+      // await tf.setBackend("webgl");
       await initVideoCamera();
       const detector = await initDetector();
       const cameraCanvas = getCameraCanvasElement();


### PR DESCRIPTION
# Why

iPhone のブラウザだとうまく動かなかった。
具体的には、カメラ映像が最初のフレームで止まって、以降動かなくなってしまっていた。
なお、FPS カウンタは動作していた。

# What

`getUserMedia` の前に、`video` タグに、`autoPlay`, `muted`, `playsInline` 属性を指定することで解消。

ref: https://otiai10.hatenablog.com/entry/2019/11/11/090124
ref: https://stackoverflow.com/questions/53483975/navigator-mediadevices-getusermedia-not-working-on-ios-12-safari/54678952

## P.S.

JSX では、`autoplay`, `playsinline` はそれぞれ、`autoPlay`, `playsInline` とする必要がある。