### PR TITLE
videoをcanvasに転写するよう調整

### DIFF
--- a/src/features/Cameras/Cameras.tsx
+++ b/src/features/Cameras/Cameras.tsx
@@ -6,10 +6,10 @@ export function Cameras() {
 
   return (
     <div id="container" className="relative shrink-0">
-      <video
-        id="video"
+      <video id="video" className="invisible" ref={videoRef} />
+      <canvas
+        id="camera-canvas"
         className="scale-x-[-1] object-cover w-screen h-[100vw] lg:w-[min(calc(100vh-64px-32px),calc(100vw-340px))] lg:h-[min(calc(100vh-64px-32px),calc(100vw-340px))] shrink-0"
-        ref={videoRef}
       />
       <canvas
         id="canvas"

--- a/src/features/Cameras/Cameras.tsx
+++ b/src/features/Cameras/Cameras.tsx
@@ -6,7 +6,7 @@ export function Cameras() {
 
   return (
     <div id="container" className="relative shrink-0">
-      <video id="video" className="invisible" ref={videoRef} />
+      <video id="video" className="hidden" ref={videoRef} />
       <canvas
         id="camera-canvas"
         className="scale-x-[-1] object-cover w-screen h-[100vw] lg:w-[min(calc(100vh-64px-32px),calc(100vw-340px))] lg:h-[min(calc(100vh-64px-32px),calc(100vw-340px))] shrink-0"

--- a/src/features/Cameras/getCharacterCorrespondsToCurrentPose.tsx
+++ b/src/features/Cameras/getCharacterCorrespondsToCurrentPose.tsx
@@ -19,10 +19,10 @@ export async function getCharacterCorrespondsToCurrentPose() {
   const cameraElement = await getCameraElement();
   const detector = await getDetector();
 
-  // drawCameraCanvas();
-  // const cameraCanvas = getCameraCanvasElement();
+  drawCameraCanvas();
+  const cameraCanvas = getCameraCanvasElement();
 
-  const poses = await detector.estimatePoses(cameraElement);
+  const poses = await detector.estimatePoses(cameraCanvas);
   if (poses.length == 1) {
     drawKeypoints(poses[0].keypoints);
   }

--- a/src/features/Cameras/getCharacterCorrespondsToCurrentPose.tsx
+++ b/src/features/Cameras/getCharacterCorrespondsToCurrentPose.tsx
@@ -2,9 +2,11 @@ import * as tf from "@tensorflow/tfjs-core";
 import { getLatestInput } from "./scripts/lib/canvas/checkInput";
 import { drawKeypoints } from "./scripts/lib/canvas/drawKeypoints";
 import { buttons_update } from "./scripts/lib/canvas/virtualButtons";
+import { drawCameraCanvas } from "./scripts/lib/drawCameraCanvas";
 import { getCameraElement } from "./scripts/lib/getCameraElement";
 import { getDetector } from "./scripts/lib/getDetector";
 import "@tensorflow/tfjs-backend-webgl";
+import { getCameraCanvasElement } from "./scripts/utils/getHTMLElement";
 
 let hasInitialized = false;
 
@@ -16,6 +18,9 @@ export async function getCharacterCorrespondsToCurrentPose() {
   }
   const cameraElement = await getCameraElement();
   const detector = await getDetector();
+
+  // drawCameraCanvas();
+  // const cameraCanvas = getCameraCanvasElement();
 
   const poses = await detector.estimatePoses(cameraElement);
   if (poses.length == 1) {

--- a/src/features/Cameras/scripts/lib/canvas/drawKeypoints.ts
+++ b/src/features/Cameras/scripts/lib/canvas/drawKeypoints.ts
@@ -1,8 +1,8 @@
 import { Keypoint } from "@tensorflow-models/pose-detection/dist/types";
 import {
+  getCameraCanvasElement,
   getCanvasContext,
   getCanvasElement,
-  getVideoElement,
 } from "@/features/Cameras/scripts/utils/getHTMLElement";
 
 // canvas上にkeypointsを元に点を描画する
@@ -10,9 +10,9 @@ import {
 export function drawKeypoints(keypoints: Keypoint[]) {
   // Canvas要素を取得
   const canvas = getCanvasElement();
-  const video = getVideoElement();
+  const cameraCanvas = getCameraCanvasElement();
 
-  matchCanvasSizeToVideo(canvas, video);
+  matchCanvasSizeToCameraCanvas(canvas, cameraCanvas);
 
   const context = getCanvasContext(canvas);
 
@@ -26,10 +26,10 @@ export function drawKeypoints(keypoints: Keypoint[]) {
 }
 
 // Canvasのサイズをvideoと合わせる
-function matchCanvasSizeToVideo(
+function matchCanvasSizeToCameraCanvas(
   canvas: HTMLCanvasElement,
-  video: HTMLVideoElement,
+  cameraCanvas: HTMLCanvasElement,
 ) {
-  canvas.width = video.videoWidth;
-  canvas.height = video.videoHeight;
+  canvas.width = cameraCanvas.width;
+  canvas.height = cameraCanvas.height;
 }

--- a/src/features/Cameras/scripts/lib/drawCameraCanvas.ts
+++ b/src/features/Cameras/scripts/lib/drawCameraCanvas.ts
@@ -8,7 +8,7 @@ export function drawCameraCanvas() {
   const cameraCanvas = getCameraCanvasElement();
 
   // キャンバスサイズを正方形にする
-  const length = Math.min(video.clientWidth, video.clientHeight);
+  const length = Math.min(video.videoWidth, video.videoHeight);
   cameraCanvas.width = length;
   cameraCanvas.height = length;
 
@@ -16,13 +16,13 @@ export function drawCameraCanvas() {
   let sx, sy;
 
   // 縦長のカメラ
-  if (video.clientWidth < video.clientHeight) {
+  if (video.videoWidth < video.videoHeight) {
     sx = 0;
-    sy = (video.clientHeight - length) / 2;
+    sy = (video.videoHeight - length) / 2;
   }
   // 横長のカメラ
   else {
-    sx = (video.clientWidth - length) / 2;
+    sx = (video.videoWidth - length) / 2;
     sy = 0;
   }
 

--- a/src/features/Cameras/scripts/lib/drawCameraCanvas.ts
+++ b/src/features/Cameras/scripts/lib/drawCameraCanvas.ts
@@ -1,0 +1,34 @@
+import {
+  getCameraCanvasElement,
+  getVideoElement,
+} from "../utils/getHTMLElement";
+
+export function drawCameraCanvas() {
+  const video = getVideoElement();
+  const cameraCanvas = getCameraCanvasElement();
+
+  // キャンバスサイズを正方形にする
+  const length = Math.min(video.clientWidth, video.clientHeight);
+  cameraCanvas.width = length;
+  cameraCanvas.height = length;
+
+  // カメラ映像をキャンバスに転写する
+  let sx, sy;
+
+  // 縦長のカメラ
+  if (video.clientWidth < video.clientHeight) {
+    sx = 0;
+    sy = (video.clientHeight - length) / 2;
+  }
+  // 横長のカメラ
+  else {
+    sx = (video.clientWidth - length) / 2;
+    sy = 0;
+  }
+
+  cameraCanvas
+    .getContext("2d")
+    ?.drawImage(video, sx, sy, length, length, 0, 0, length, length);
+
+  // TODO: スケールを調整する
+}

--- a/src/features/Cameras/scripts/utils/getHTMLElement.ts
+++ b/src/features/Cameras/scripts/utils/getHTMLElement.ts
@@ -38,3 +38,11 @@ export function getElementById(id: string) {
   }
   return element;
 }
+
+export function getCameraCanvasElement() {
+  const camera = document.getElementById("camera-canvas");
+  if (!isCanvasElement(camera)) {
+    throw new Error("Canvas element not found or is not a canvas element");
+  }
+  return camera;
+}


### PR DESCRIPTION
# Why
* videoタグをdisplay:noneにするとestimateposesでエラーが発生するため解消

# What
* canvasを追加して、videoを転写