### PR TITLE
身体全体を映すよう促す表示を追加

### DIFF
--- a/src/features/Camera/getCharacterCorrespondsToCurrentPose.tsx
+++ b/src/features/Camera/getCharacterCorrespondsToCurrentPose.tsx
@@ -1,3 +1,4 @@
+import { centeringPrompt } from "./scripts/lib/canvas/centeringPrompt";
 import { getLatestInput } from "./scripts/lib/canvas/checkInput";
 import { drawKeypoints } from "./scripts/lib/canvas/drawKeypoints";
 import { buttons_update } from "./scripts/lib/canvas/virtualButtons";
@@ -24,6 +25,7 @@ export async function getCharacterCorrespondsToCurrentPose() {
     drawKeypoints(poses[0].keypoints);
   }
   buttons_update(poses);
+  centeringPrompt(poses);
   const newCharacter = getLatestInput();
   return newCharacter;
 }

--- a/src/features/Camera/scripts/lib/canvas/centeringPrompt.ts
+++ b/src/features/Camera/scripts/lib/canvas/centeringPrompt.ts
@@ -6,6 +6,8 @@ import {
   getCameraCanvasElement,
 } from "@/features/Cameras/scripts/utils/getHTMLElement";
 
+const img = new Image();
+img.src = "https://svgsilh.com/svg/310276.svg";
 const centeringPromptText = "全身を中央に映してください";
 
 let fontSize = 1;
@@ -39,6 +41,10 @@ export function centeringPrompt(poses: Pose[]) {
 
   for (let target of virtualButtons.valid_keypoints) {
     if (!contains(keypoints, target)) {
+      cameraContext.globalAlpha = 0.4;
+      cameraContext.drawImage(img, 0, 0, canvas.width, canvas.height);
+      cameraContext.globalAlpha = 1;
+
       cameraContext.textAlign = "center";
       cameraContext.scale(-1, 1); // キャンバスが水平反転しているので文字も反転させる
       cameraContext.fillStyle = "red";

--- a/src/features/Camera/scripts/lib/canvas/centeringPrompt.ts
+++ b/src/features/Camera/scripts/lib/canvas/centeringPrompt.ts
@@ -4,7 +4,7 @@ import {
   getCanvasContext,
   getCanvasElement,
   getCameraCanvasElement,
-} from "@/features/Cameras/scripts/utils/getHTMLElement";
+} from "@/features/Camera/scripts/utils/getHTMLElement";
 
 // const img = new NextImage()
 // img.src = "https://svgsilh.com/svg/310276.svg";

--- a/src/features/Camera/scripts/lib/canvas/centeringPrompt.ts
+++ b/src/features/Camera/scripts/lib/canvas/centeringPrompt.ts
@@ -1,0 +1,64 @@
+import { Keypoint, Pose } from "@tensorflow-models/pose-detection/dist/types";
+import { virtualButtons, findKeypointByName } from "./virtualButtons";
+import {
+  getCanvasContext,
+  getCanvasElement,
+  getCameraCanvasElement,
+} from "@/features/Cameras/scripts/utils/getHTMLElement";
+
+const centeringPromptText = "全身を中央に映してください";
+
+let fontSize = 1;
+let centeringPromptFont = `bold ${fontSize}px sans-serif`;
+
+export function initCenteringPromptFontSize() {
+  // Canvas要素を取得
+  const cameraCanvas = getCameraCanvasElement();
+  const cameraContext = getCanvasContext(cameraCanvas);
+
+  cameraContext.textAlign = "center";
+  cameraContext.scale(-1, 1); // キャンバスが水平反転しているので文字も反転させる
+  cameraContext.fillStyle = "red";
+  cameraContext.font = centeringPromptFont;
+  let textWidth = cameraContext.measureText(centeringPromptText).width;
+
+  while (textWidth < cameraCanvas.width * 0.8) {
+    fontSize++;
+    centeringPromptFont = `bold ${fontSize}px sans-serif`;
+    cameraContext.font = centeringPromptFont;
+    textWidth = cameraContext.measureText(centeringPromptText).width;
+  }
+}
+
+export function centeringPrompt(poses: Pose[]) {
+  // Canvas要素を取得
+  const canvas = getCanvasElement();
+  const cameraContext = getCanvasContext(canvas);
+
+  let keypoints: Keypoint[] = poses.length != 0 ? poses[0].keypoints : Array();
+
+  for (let target of virtualButtons.valid_keypoints) {
+    if (!contains(keypoints, target)) {
+      cameraContext.textAlign = "center";
+      cameraContext.scale(-1, 1); // キャンバスが水平反転しているので文字も反転させる
+      cameraContext.fillStyle = "red";
+      cameraContext.font = centeringPromptFont;
+      cameraContext.fillText(
+        centeringPromptText,
+        -canvas.width / 2, // scale で反転させているため負の値にする
+        (canvas.height * 2) / 3,
+      );
+
+      return;
+    }
+  }
+}
+
+function contains(keypoints: Keypoint[], target: string) {
+  let pnt = findKeypointByName(keypoints, target);
+
+  if (pnt == null) return false;
+  if (pnt.score && pnt.score < 0.3) return false;
+
+  return true;
+}

--- a/src/features/Camera/scripts/lib/canvas/centeringPrompt.ts
+++ b/src/features/Camera/scripts/lib/canvas/centeringPrompt.ts
@@ -1,4 +1,3 @@
-import { draw } from "@tensorflow/tfjs-core/dist/ops/browser";
 import { Keypoint, Pose } from "@tensorflow-models/pose-detection/dist/types";
 import { virtualButtons, contains, findKeypointByName } from "./virtualButtons";
 import {
@@ -7,8 +6,8 @@ import {
   getCameraCanvasElement,
 } from "@/features/Cameras/scripts/utils/getHTMLElement";
 
-const img = new Image();
-img.src = "https://svgsilh.com/svg/310276.svg";
+// const img = new NextImage()
+// img.src = "https://svgsilh.com/svg/310276.svg";
 const centeringPromptText = "全身を中央に映してください";
 
 let fontSize = 1;
@@ -75,9 +74,9 @@ function drawCenteringPrompt() {
   const canvas = getCanvasElement();
   const cameraContext = getCanvasContext(canvas);
 
-  cameraContext.globalAlpha = 0.4;
-  cameraContext.drawImage(img, 0, 0, canvas.width, canvas.height);
-  cameraContext.globalAlpha = 1;
+  // cameraContext.globalAlpha = 0.4;
+  // cameraContext.drawImage(img, 0, 0, canvas.width, canvas.height);
+  // cameraContext.globalAlpha = 1;
 
   cameraContext.textAlign = "center";
   cameraContext.scale(-1, 1); // キャンバスが水平反転しているので文字も反転させる

--- a/src/features/Camera/scripts/lib/canvas/virtualButtons.ts
+++ b/src/features/Camera/scripts/lib/canvas/virtualButtons.ts
@@ -109,7 +109,7 @@ function buttons_draw(poses: Pose[]) {
   }
 }
 
-function findKeypointByName(
+export function findKeypointByName(
   keypoints: Keypoint[],
   targetName: string,
 ): Keypoint | undefined {

--- a/src/features/Camera/usePoseDetection.ts
+++ b/src/features/Camera/usePoseDetection.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useBodyProgrammingEditor } from "../BodyProgrammingEditor/bodyProgrammingEditorContext";
 import { useCode } from "../Code/codeContext";
 import { animate } from "./animate";
+import { initCenteringPromptFontSize } from "./scripts/lib/canvas/centeringPrompt";
 import { initVirtualButtons } from "./scripts/lib/canvas/virtualButtons";
 import { getDetector } from "./scripts/lib/getDetector";
 
@@ -24,6 +25,7 @@ export function usePoseDetection() {
     const currentVideoRef = videoRef.current;
     initVirtualButtons();
     initDetector();
+    initCenteringPromptFontSize();
 
     return () => {
       console.log("unmount");


### PR DESCRIPTION
# What

以下のどれか 1 つでも満たす場合は、画像のようにキャンバス内に文字を登場させる。

- 鼻のキーポイントが映っていない
- 左右の手首のキーポイントが映っていない
- 左右の足首のキーポイントの両方が最下部の領域（0 始まりで 2 行目）にない

![Screenshot 2024-01-17 at 04-13-20 Create Next App](https://github.com/mznms/physi-code/assets/93835511/02781521-7bdd-4ae7-8d13-b4c0292e8e27)

## PS

キャンバス内に人型の SVG 画像出したかったんだけど出せませんでした